### PR TITLE
Operation/refactor addon deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,31 @@
 # Restaurant review sentiment predictor
 
-1. [Continuous experimentation](#continuous-experimentation-a3)
-2. [Run the app (A2)](#run-the-app-a2)
+1. [Infrastructure touch up](#infrastructure-touch-up-a6)
+2. [Continuous experimentation](#continuous-experimentation-a3)
+3. [Run the app (A2)](#run-the-app-a2)
     * [Docker compose](#docker-compose)
     * [Helm chart](#helm-chart)
-3. [App](#app)
-4. [Model service](#model-service)
-5. [Prometheus](#prometheus)
-6. [Grafana](#grafana)
+4. [App](#app)
+5. [Model service](#model-service)
+6. [Prometheus](#prometheus)
+7. [Grafana](#grafana)
+
+## Infrastructure touch up (A6)
+
+The Helm chart has been modified to not include the kube-prometheus-stack dependency. This dependency is not a prerequisite to run our core
+application. As such we have put the template files for Istio, Prometheus and Grafana behind feature flags in values.yaml.
+The user of this chart therefore has the option to choose if they want to use these infrastructure and monitoring tools for their
+own cluster.
+
+Here are documentation links for some of the most common monitoring and infrastructure applications:
+* [Istio](https://istio.io/latest/docs/setup/getting-started/) and [Integration](https://istio.io/latest/docs/ops/integrations/)
+* [Kube Prometheus Stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
+* [Jaeger](https://www.jaegertracing.io/docs/1.46/getting-started/)
+* [Kiali](https://kiali.io/docs/installation/quick-start/)
+* [Prometheus](https://prometheus.io/docs/prometheus/latest/getting_started/)
+* [Grafana](https://grafana.com/docs/grafana/latest/getting-started/)
+
+
 
 ## Continuous experimentation (A3)
 

--- a/remla23-team10-restaurant/Chart.lock
+++ b/remla23-team10-restaurant/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: kube-prometheus-stack
-  repository: https://prometheus-community.github.io/helm-charts
-  version: 45.27.2
-digest: sha256:18d5415c150ba1298226d8c2a1fca6d0d9f979a1188e99bf8ba3f2d295ceafec
-generated: "2023-05-30T15:29:56.619764067+02:00"

--- a/remla23-team10-restaurant/Chart.yaml
+++ b/remla23-team10-restaurant/Chart.yaml
@@ -17,11 +17,6 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
 
-dependencies:
-  - name: kube-prometheus-stack
-    version: 45.27.2
-    repository: https://prometheus-community.github.io/helm-charts
-    condition: deploy-prom-stack
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/remla23-team10-restaurant/templates/alertmanager-config.yaml
+++ b/remla23-team10-restaurant/templates/alertmanager-config.yaml
@@ -1,3 +1,4 @@
+{{if .Values.prometheus.enabled}}
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:
@@ -10,13 +11,13 @@ spec:
     receiver: 'smtp'
     matchers:
       - name: severity
-        value: {{ .Values.alertConfig.severity }}
+        value: {{ .Values.prometheus.alertConfig.severity }}
 
 
   receivers:
     - name: 'smtp'
       emailConfigs:
-      {{- range .Values.alertConfig.emails }}
+      {{- range .Values.prometheus.alertConfig.emails }}
         - to: {{.to}}
           from: {{.from}}
           smarthost: {{.smtphost}}
@@ -27,3 +28,4 @@ spec:
             key: {{.name}}
           sendResolved: true
       {{- end}}
+{{end}}

--- a/remla23-team10-restaurant/templates/alertrules.yaml
+++ b/remla23-team10-restaurant/templates/alertrules.yaml
@@ -1,3 +1,4 @@
+{{if .Values.prometheus.enabled}}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -16,3 +17,4 @@ spec:
           annotations:
             summary: Too many prediction errors
             description: "The rate of prediction errors is greater than 50% in the last minute (current value: {{"{{ $value }}"}})."
+{{end}}

--- a/remla23-team10-restaurant/templates/configmap-dashboards.yaml
+++ b/remla23-team10-restaurant/templates/configmap-dashboards.yaml
@@ -1,5 +1,5 @@
 {{- $files := .Files.Glob "dashboards/*.json" }}
-{{- if $files }}
+{{- if and $files .Values.grafana.enabled }}
 apiVersion: v1
 kind: ConfigMapList
 items:
@@ -8,7 +8,7 @@ items:
   - apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" $) $dashboardName | trunc 63 | trimSuffix "-" }}
+      name: {{ $dashboardName}}
       labels:
         grafana_dashboard: "1"
         app: {{ $.Release.Name }}-grafana

--- a/remla23-team10-restaurant/templates/deployment.yaml
+++ b/remla23-team10-restaurant/templates/deployment.yaml
@@ -17,6 +17,10 @@ spec:
         app: {{ $webapp.selectorLabel }}
         version: {{ $tag.version }}
         sidecar.istio.io/inject: "true"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/actuator/prometheus"
+        prometheus.io/port: "8080"
     spec:
       containers:
         - name: {{ $webapp.podname }}

--- a/remla23-team10-restaurant/templates/destinationrules.yaml
+++ b/remla23-team10-restaurant/templates/destinationrules.yaml
@@ -1,3 +1,4 @@
+{{if .Values.istio.enabled}}
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -25,3 +26,4 @@ spec:
     - name: v1
       labels:
         version: v1
+{{end}}

--- a/remla23-team10-restaurant/templates/envoyfilter.yaml
+++ b/remla23-team10-restaurant/templates/envoyfilter.yaml
@@ -1,3 +1,4 @@
+{{if .Values.istio.enabled}}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -43,3 +44,4 @@ spec:
                   header:
                     key: x-local-rate-limit
                     value: 'true'
+{{end}}

--- a/remla23-team10-restaurant/templates/gateway.yaml
+++ b/remla23-team10-restaurant/templates/gateway.yaml
@@ -1,3 +1,4 @@
+{{if .Values.istio.enabled}}
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -12,3 +13,4 @@ spec:
         protocol: HTTP
       hosts:
         - "*"
+{{end}}

--- a/remla23-team10-restaurant/templates/secrets.yaml
+++ b/remla23-team10-restaurant/templates/secrets.yaml
@@ -1,8 +1,10 @@
+{{if .Values.prometheus.enabled}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: smtp-secrets
 data:
-  {{- range .Values.alertConfig.emails }}
+  {{- range .Values.prometheus.alertConfig.emails }}
   {{ .name }}: {{ .password | b64enc }}
   {{- end }}
+{{end}}

--- a/remla23-team10-restaurant/templates/service-monitor.yaml
+++ b/remla23-team10-restaurant/templates/service-monitor.yaml
@@ -1,3 +1,4 @@
+{{if .Values.prometheus.enabled}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -11,3 +12,4 @@ spec:
   endpoints:
   - interval: {{.Values.serviceMonitor.interval }}
     path: /actuator/prometheus
+{{end}}

--- a/remla23-team10-restaurant/templates/virtualservice.yaml
+++ b/remla23-team10-restaurant/templates/virtualservice.yaml
@@ -1,3 +1,4 @@
+{{if .Values.istio.enabled}}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -8,6 +9,7 @@ spec:
   hosts:
     - "*"
   http:
+    {{if .Values.prometheus.enabled}}
     - match:
         - uri:
             prefix: /prometheus
@@ -16,7 +18,8 @@ spec:
             host: {{.Release.Name}}-kube-prometheus-stac-prometheus
             port:
               number: 9090
-
+    {{end}}
+    {{if .Values.grafana.enabled}}
     - match:
         - uri:
             prefix: /grafana
@@ -25,7 +28,7 @@ spec:
             host: {{.Release.Name}}-grafana
             port:
               number: 80
-
+      {{end}}
     - match:
         - headers:
             cookie:
@@ -84,3 +87,4 @@ spec:
     - destination:
         host: {{$.Values.services.modelService.name}}
         subset: v0
+{{end}}

--- a/remla23-team10-restaurant/values.yaml
+++ b/remla23-team10-restaurant/values.yaml
@@ -46,44 +46,25 @@ serviceMonitor:
   interval: 30s
 
 
-# Deploy the prometheus stack. Can be disabled if you already have a prometheus stack deployed
-deploy-prom-stack: true
-
-# alertmanager config
-alertConfig:
-  severity: warning # minimum level of severity for notification
-
-# List of email configurations. Example using gmail
-  emails:
-    - name: user                        # name of the config
-      to: user@gmail.com                # email to send notifications to
-      from: reveiver@example.com        # email to send notifications from
-      smtp: smtp.gmail.com:587          # smtp server and port
-      username: user@gmail.com          # identity for smtp server
-      password: "CHANGE-ME"             # password for smtp server
+# If prometheus is used, describe if the predefined AlertManager, PrometheusRule and ServiceMonitor should be deployed as well
+prometheus:
+  enabled: true
+  alertConfig:
+    severity: warning # minimum level of severity for notification
+      # List of email configurations. Example using gmail
+    emails:
+        - name: user                        # name of the config
+          to: user@gmail.com                # email to send notifications to
+          from: reveiver@example.com        # email to send notifications from
+          smtp: smtp.gmail.com:587          # smtp server and port
+          username: user@gmail.com          # identity for smtp server
+          password: "CHANGE-ME"             # password for smtp server
       # See https://support.google.com/accounts/answer/185833?hl=en for more info on Gmail app passwords
 
-kube-prometheus-stack:
-  prometheus:
-    prometheusSpec:
-      externalUrl: http://localhost/prometheus
-      routePrefix: /prometheus
+# If grafana is used, describe if the predefined dashboards in "dashboards" should be deployed as well
+grafana:
+  enabled: true
 
-  alertmanager:
-    config:
-      global:
-        resolve_timeout: 1m
-        # Default smpt server. Ideally same as one of the configs above, but it does not matter
-        # since it will use the values from the config.
-        # However, the alertmanager refuses to start if there is at least one email reveiver
-        # and not a global default smtp server. https://github.com/prometheus/alertmanager/issues/275
-        smtp_smarthost: smtp.gmail.com:587
-
-  # Grafana configuration
-  grafana:
-    env:
-      GF_SERVER_ROOT_URL: https://localhost:3000/grafana
-      GF_SERVER_SERVE_FROM_SUB_PATH: 'true'
-    # username is 'admin'
-    adminPassword: prom-operator
-    defaultDashboardsEnabled: false
+# If istio is used, describe if the predefined DestinationRule, EnvoyFilter, Gateway and VirtualService should be deployed as well
+istio:
+  enabled: true


### PR DESCRIPTION
This MR deletes kube-prometheus-stack. This makes it such that the user has to install the infrastructure (istio, prometheus, grafana, etc etc) all on its own if the user decides to use these tools or not. We only give the possibility to use our templates made for these tools behind a values file. 